### PR TITLE
Add "fiction" filter

### DIFF
--- a/src/main/java/se/kb/libris/export/ExportProfile.java
+++ b/src/main/java/se/kb/libris/export/ExportProfile.java
@@ -86,6 +86,28 @@ public class ExportProfile {
         return false;
     }
 
+    public static boolean isFiction(MarcRecord mr) {
+        Iterator iter000 = mr.iterator("000");
+        if (iter000.hasNext()) {
+            Controlfield cf = (Controlfield)iter000.next();
+            /// not Text or not Monograph
+            if (cf.getChar(6) != 'a' || cf.getChar(7) != 'm') {
+                return false;
+            }
+        }
+
+        Iterator iter008 = mr.iterator("008");
+        if (iter008.hasNext()) {
+            Controlfield cf = (Controlfield)iter008.next();
+            // BooksLiteraryFormType ...
+            char bookstype = cf.getChar(33);
+            // ... is either undefined or NotFictionNotFurtherSpecified
+            return bookstype != ' ' && bookstype != '|' && bookstype != '0';
+        }
+
+        return false;
+    }
+
     public static boolean isLicenseRecord(MarcRecord mr) {
         Iterator iter = mr.iterator("040");
 
@@ -107,6 +129,7 @@ public class ExportProfile {
         if (getProperty("biblevel", "off").equalsIgnoreCase("ON") && isPrelInfo(mr)) return true;
         if (getProperty("licensefilter", "off").equalsIgnoreCase("ON") && isLicenseRecord(mr)) return true;
         if (getProperty("efilter", "off").equalsIgnoreCase("ON") && isEResource(mr)) return true;
+        if (getProperty("fiction", "off").equalsIgnoreCase("ON") && isFiction(mr)) return true;
 
         return false;
     }


### PR DESCRIPTION
This is an initial stab at the filter.

Returns true for Monograph Text with either no BooksLiteraryFormType or NotFictionNotFurtherSpecified.

We need to test this properly and expose this flag in the marcexportgui.

Note that `marc:NotFictionNotFurtherSpecified` (`bib 008[33] == '0'`) is unreliable today! It is set for a lot of resources which we know *are* fiction. We are working to clean this up and normalize the "is fiction" facts (using genreForm terms from SAOGF), and generate the appropriate value in bib 008[33] on the way out! Given that manoeuvre, this filter will be much more reliable.